### PR TITLE
Feature/add backoff method

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -3,15 +3,13 @@ name: Ruby Gem
 on:
   push:
     branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [ '3.0', '3.1' ]
+        ruby-version: [ '3.0', '3.1', '3.2' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 
 # rspec failure tracking
 .rspec_status
+
+# jetbrains directories
+/.idea
+/.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    block_repeater (1.0.0)
+    block_repeater (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ The repeater also takes two parameters:
    repeat (delay: 0.5, times: 10){ call_database_method }.until{ |result| result.count.positive? }
  ```
 
+### Backoff method
+This is a slightly different take on the preferred `repeat` method. It retries a call whilst exponentially increasing the wait time between each iteration until a timeout is reached.
+
+```ruby
+repeat do
+  call_method
+end.until do |result|
+  result
+end.backoff(timeout: 10, initial_wait: 0.5, multiplier: 2)
+```
+
+`backoff` takes three paramaters:
+- `timeout:` is how long you want your repeater to run
+- `initial_wait:` is how long you want to pause before your first retry
+- `multiplier:` is the rate at which you increase the wait time between each iteration
+
 ### Exception Handling
 Using the `catch` method you can define how the repeater should respond to specific exception types. To do this you need to provide a list of exceptions to catch, a block of code which will be performed, and an option for how to trigger than block of code.
 

--- a/lib/block_repeater/repeater.rb
+++ b/lib/block_repeater/repeater.rb
@@ -2,6 +2,7 @@
 
 require 'block_repeater/repeater_methods'
 require 'block_repeater/exception_response'
+require 'logger'
 
 ##
 # A way to repeatedly execute a block of code until a given condition is met or a timeout is reached
@@ -9,6 +10,7 @@ module BlockRepeater
   ##
   # The class which governs when to stop repeating based on condition or timeout
   class Repeater
+    LOGGER = Logger.new($stdout)
     include RepeaterMethods
     @@default_exceptions = []
 
@@ -45,8 +47,8 @@ module BlockRepeater
           deferred_exception = nil
         rescue *exception_types => e
           exceptions = if anticipated_exception_types.any? do |ex|
-                            e.class <= ex
-                          end
+            e.class <= ex
+          end
                          @anticipated_exceptions
                        else
                          @@default_exceptions
@@ -69,6 +71,40 @@ module BlockRepeater
 
       deferred_exception&.execute
 
+      result
+    end
+
+    # Retry a call whilst exponentially increasing the wait time between each iteration until a timeout is reached
+    # @param [Integer] `timeout` is the max amount wait of time you wish to try the action
+    # @param [Integer] `initial_wait` is the initial wait time to retry the action
+    # @param [Integer] `multiplier` is the rate at which you increase the wait time between each iteration
+    def backoff(timeout: 10, initial_wait: 0.1, multiplier: 2)
+      raise StandardError, 'Multiplier cannot be less than 1.1' if multiplier < 1.1
+
+      condition_met = nil
+      result = nil
+
+      current_sleep_seconds = initial_wait
+      start_time = Time.now
+
+      until current_sleep_seconds >= timeout
+        result = @repeat_block.call
+        condition_met = @condition_block.call(result) if @condition_block
+
+        duration = Time.now - start_time
+
+        LOGGER.warn "Timeout reached on fallback - Duration: #{duration} - Timeout: #{timeout} seconds" if duration > timeout
+        break if condition_met || duration > timeout
+
+        # calculating exponential increase
+        current_sleep_seconds = current_sleep_seconds * multiplier
+        # how long the total duration will be after the next sleep
+        projected_duration = current_sleep_seconds + duration
+        # if projected duration exceeds the timeout, reduce time for next sleep to allow one final call
+        current_sleep_seconds = (timeout - duration) if projected_duration > timeout
+
+        sleep(current_sleep_seconds)
+      end
       result
     end
 

--- a/lib/block_repeater/repeater.rb
+++ b/lib/block_repeater/repeater.rb
@@ -93,11 +93,14 @@ module BlockRepeater
 
         duration = Time.now - start_time
 
-        LOGGER.warn "Timeout reached on fallback - Duration: #{duration} - Timeout: #{timeout} seconds" if duration > timeout
+        if duration > timeout
+          LOGGER.warn "Timeout reached on fallback - Duration: #{duration} - Timeout: #{timeout} seconds"
+        end
+
         break if condition_met || duration > timeout
 
         # calculating exponential increase
-        current_sleep_seconds = current_sleep_seconds * multiplier
+        current_sleep_seconds *= multiplier
         # how long the total duration will be after the next sleep
         projected_duration = current_sleep_seconds + duration
         # if projected duration exceeds the timeout, reduce time for next sleep to allow one final call

--- a/lib/block_repeater/repeater.rb
+++ b/lib/block_repeater/repeater.rb
@@ -94,7 +94,7 @@ module BlockRepeater
         duration = Time.now - start_time
 
         if duration > timeout
-          LOGGER.warn "Timeout reached on fallback - Duration: #{duration} - Timeout: #{timeout} seconds"
+          LOGGER.debug "Timeout reached on fallback - Duration: #{duration} - Timeout: #{timeout} seconds"
         end
 
         break if condition_met || duration > timeout

--- a/lib/block_repeater/repeater.rb
+++ b/lib/block_repeater/repeater.rb
@@ -2,7 +2,6 @@
 
 require 'block_repeater/repeater_methods'
 require 'block_repeater/exception_response'
-require 'logger'
 
 ##
 # A way to repeatedly execute a block of code until a given condition is met or a timeout is reached
@@ -10,7 +9,6 @@ module BlockRepeater
   ##
   # The class which governs when to stop repeating based on condition or timeout
   class Repeater
-    LOGGER = Logger.new($stdout)
     include RepeaterMethods
     @@default_exceptions = []
 
@@ -92,10 +90,6 @@ module BlockRepeater
         condition_met = @condition_block.call(result) if @condition_block
 
         duration = Time.now - start_time
-
-        if duration > timeout
-          LOGGER.debug "Timeout reached on fallback - Duration: #{duration} - Timeout: #{timeout} seconds"
-        end
 
         break if condition_met || duration > timeout
 

--- a/lib/block_repeater/version.rb
+++ b/lib/block_repeater/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BlockRepeater
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/block_repeater/repeater_spec.rb
+++ b/spec/block_repeater/repeater_spec.rb
@@ -52,4 +52,43 @@ RSpec.describe BlockRepeater::Repeater do
       expect(result).to eql(5)
     end
   end
+
+  describe '#backoff' do
+    # 0.1 with a multiple of 2 should run 8 times in total
+    it 'repeats 8 times if default values are used' do
+      result = 1
+      subject.new do
+        result += 1
+      end.backoff
+      expect(result).to eql(8)
+    end
+
+    it 'repeats x times if custom values are used' do
+      result = 1
+      subject.new do
+        result += 1
+      end.backoff(timeout: 20, initial_wait: 1)
+      expect(result).to eql(6)
+    end
+
+    it 'returns once the condition is met' do
+      result = 0
+      subject.new do
+        result += 1
+      end.until do |output|
+        output == 3
+      end.backoff
+      expect(result).to eql(3)
+    end
+
+    it 'does not return early if the exit condition is not met' do
+      result = 1
+      subject.new do
+        result += 1
+      end.until do
+        result == 0
+      end.backoff
+      expect(result).to eql(8)
+    end
+  end
 end


### PR DESCRIPTION
- Bumped version to 1.1.0
- Add new function called `backoff` that uses the concept of exponential backoff.   This can be used to repeat on things like API/database calls where the service might struggle under load and gives you a chance to repeat without overloading the service.
- spec tests added