### PR TITLE
Feature/update readme on re raise exception usage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    block_repeater (1.1.0)
+    block_repeater (1.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ You can also define default exception handling behaviour which all repeaters in 
 ```ruby
 BlockRepeater::Repeater.default_catch(exceptions: [IOError], behaviour: :defer) do |e|
   puts 'An IOError occurred'
-  e.raise
+  raise e
 end
 ```
 A common use-case for default exception handling is if using a gem such as RSpec, where you may want to handle failed expectations in a uniform manner. To do so you need define the default behaviour first, in a place such as a `env.rb` file or similar:
 ```ruby
 BlockRepeater::Repeater.default_catch(exceptions: [RSpec::Expectations::ExpectationNotMetError], behaviour: :defer) do |e|
-  e.raise
+  raise e
 end
 ```
 Then an RSpec expectation can be used in the block for the `until` method. The expectation will be attempted each try, but the exception will only be raised if it has still failed once the number or attempts has been reached.

--- a/lib/block_repeater/version.rb
+++ b/lib/block_repeater/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BlockRepeater
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
Update README to correct the usage of re raising exception in the block repeater configuration.
`Kernel#raise` is a private method and cannot be called on any instance other than the `Kernel` instance.